### PR TITLE
PLAT-20201 - chore: migra imagens do dockerhub para ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ run that old project...
 Just run:
 
 ```bash
-docker run -it caninjas/jdk6 /bin/bash
+docker run -it 439291037095.dkr.ecr.us-east-2.amazonaws.com/base/jdk6:latest /bin/bash
 ```


### PR DESCRIPTION
Migração automatizada: imagens `caninjas/*` → ECR.

## Substituições

### `README.md`

- `caninjas/jdk6` → `439291037095.dkr.ecr.us-east-2.amazonaws.com/base/jdk6:latest` _(origem da tag: `fallback`)_

---

Gerada por `scripts/plan_caninjas_to_ecr_migration.py --create-prs`.