### PR TITLE
PLAT-20201 - chore: migra imagens do dockerhub para ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [docker-jdk6](https://registry.hub.docker.com/u/caninjas/jdk6/)
+# [docker-jdk6](https://r439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/base/jdk6/)
 
 Docker image with Oracle JDK6, Maven 3.2.5 and Git. You can use it to
 run that old project...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [docker-jdk6](https://r439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/base/jdk6/)
+# [docker-jdk6](https://439291037095.dkr.ecr.us-east-2.amazonaws.com/microservice/base/jdk6/)
 
 Docker image with Oracle JDK6, Maven 3.2.5 and Git. You can use it to
 run that old project...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker image registry reference from Docker Hub to AWS ECR.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ContaAzul/docker-jdk6/pull/4)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->